### PR TITLE
Rework search request

### DIFF
--- a/src/app/components/search-controls.test.tsx
+++ b/src/app/components/search-controls.test.tsx
@@ -1,13 +1,13 @@
 import { cleanup, fireEvent, render } from '@testing-library/react';
-import type { Client } from 'typesense';
+// import type { Client } from 'typesense';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import SearchControls from './search-controls';
 
 const defaultProps = {
-  query: 'Мельник',
+  initialValue: 'Мельник',
   areRefinementsExpanded: false,
-  client: {} as Client,
+  // client: {} as Client,
   onFacetChange: vi.fn(),
   onRangeChange: vi.fn(),
   onToggleRefinementsExpanded: vi.fn(),
@@ -31,7 +31,7 @@ describe('SearchControls component', () => {
       <SearchControls {...defaultProps} />,
     );
     const input = getByPlaceholderText('Мельник');
-    expect(input).toHaveValue(defaultProps.query);
+    expect(input).toHaveValue(defaultProps.initialValue);
   });
 
   it('should call onInput when the input value changes', () => {

--- a/src/app/components/search-controls.tsx
+++ b/src/app/components/search-controls.tsx
@@ -1,29 +1,17 @@
-import {
-  type ChangeEvent,
-  type FC,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
-
-import getTypesenseClient from '../services/typesense';
+import { type ChangeEvent, type FC, useCallback, useState } from 'react';
 
 import styles from './search-controls.module.css';
 
 interface ControlsProperties {
-  query: string;
-  client: ReturnType<typeof getTypesenseClient>;
+  initialValue: string;
   onInput: (event: CustomEvent<string>) => void;
 }
 
-const SearchControls: FC<ControlsProperties> = ({ query, onInput }) => {
-  const [inputValue, setInputValue] = useState(query);
-  const inputReference = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    setInputValue(query);
-  }, [query]);
+// This input is responsible only for changing value within itself.
+// The only source of change is user input, though it can take initial value
+// from query or other source.
+const SearchControls: FC<ControlsProperties> = ({ initialValue, onInput }) => {
+  const [inputValue, setInputValue] = useState(initialValue);
 
   const handleInputChange = useCallback(
     (changeEvent: ChangeEvent<HTMLInputElement>) => {
@@ -34,18 +22,6 @@ const SearchControls: FC<ControlsProperties> = ({ query, onInput }) => {
         detail: newValue,
       });
       onInput(event);
-
-      if (inputReference.current) {
-        const { selectionStart, selectionEnd } = changeEvent.target;
-        setTimeout(() => {
-          if (inputReference.current) {
-            inputReference.current.setSelectionRange(
-              selectionStart,
-              selectionEnd,
-            );
-          }
-        }, 0);
-      }
     },
     [onInput],
   );
@@ -55,13 +31,12 @@ const SearchControls: FC<ControlsProperties> = ({ query, onInput }) => {
     <div className={styles.container} role="search">
       <input
         id="genealogical-indexes-search"
-        ref={inputReference}
-        type="text"
+        type="search"
         value={inputValue}
         onChange={handleInputChange}
         className={styles.input}
         placeholder="Мельник"
-        autoFocus={!query}
+        autoFocus={!initialValue}
         aria-label="Шукати в генеалогічних індексах"
       />
     </div>

--- a/src/app/components/search-results.test.tsx
+++ b/src/app/components/search-results.test.tsx
@@ -12,6 +12,7 @@ vi.mock('../schemas/search-result', () => ({
 }));
 
 const defaultProps = {
+  searchValue: 'Мельник',
   loading: false,
   recordsNumber: 10,
   results: [
@@ -65,7 +66,9 @@ describe('SearchResults component', () => {
 
   it('should render the correct number of results', () => {
     const { getByText } = render(<SearchResults {...defaultProps} />);
-    expect(getByText('Знайдено результатів: 2')).toBeInTheDocument();
+    expect(
+      getByText('Знайдено результатів для "Мельник": 2'),
+    ).toBeInTheDocument();
   });
 
   it('should render the correct number of tbody elements', () => {

--- a/src/app/components/search-results.tsx
+++ b/src/app/components/search-results.tsx
@@ -7,6 +7,7 @@ import type { SearchResult } from '../services/search';
 import styles from './search-results.module.css';
 
 export interface ResultsProperties {
+  searchValue: string;
   loading: boolean;
   recordsNumber: number;
   results: SearchResult[];
@@ -14,6 +15,7 @@ export interface ResultsProperties {
 }
 
 const SearchResults: FC<ResultsProperties> = ({
+  searchValue,
   loading,
   recordsNumber,
   results,
@@ -24,10 +26,14 @@ const SearchResults: FC<ResultsProperties> = ({
     // TODO add accessible and more visible loader on loading
     <table className={styles.table} style={{ opacity: loading ? 0.5 : 1 }}>
       <caption className={styles.caption}>
-        {resultsNumber ? (
-          <>Знайдено результатів: {resultsNumber}</>
-        ) : (
+        {loading && !resultsNumber ? (
+          <>Завантаження...</>
+        ) : !searchValue && !resultsNumber ? (
           <>Всього рядків у таблицях: {recordsNumber}</>
+        ) : (
+          <>
+            Знайдено результатів для "{searchValue}": {resultsNumber}
+          </>
         )}
       </caption>
       {results.map((result, index) => {
@@ -46,7 +52,7 @@ const SearchResults: FC<ResultsProperties> = ({
                   <tr key={`${key}-${index}`}>
                     <th scope="row">{key}</th>
                     <td
-                      className="snippet"
+                      className="snippet break-word"
                       dangerouslySetInnerHTML={{
                         __html: value.snippet,
                       }}

--- a/src/app/components/use-search.tsx
+++ b/src/app/components/use-search.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import type { NotifiableError } from '@bugsnag/js';
+import { useCallback, useState } from 'react';
+
+import environment from '../environment';
+import ActiveBugsnag from '../services/bugsnag';
+import search, { type SearchResult } from '../services/search';
+import trackEvent from '../services/simple-analytics';
+import getTypesenseClient from '../services/typesense';
+
+const apiKey = environment.NEXT_PUBLIC_TYPESENSE_SEARCH_KEY;
+const host = environment.NEXT_PUBLIC_TYPESENSE_HOST;
+const client = getTypesenseClient(apiKey, host);
+
+export function useSearch() {
+  // TODO rework it to the common data/isLoading/error structure?
+  // TODO add isFetched or other similar variables for appropriate display of results and its state
+  const [searchValue, setSearchValue] = useState('');
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [resultsNumber, setResultsNumber] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSearch = useCallback(async (value: string) => {
+    setSearchValue(value);
+    if (!value) {
+      setResults([]);
+      setResultsNumber(0);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      trackEvent('search', { query: value });
+      const [hits, hitsNumber] = await search({
+        client,
+        // facets,
+        query: value,
+        // ranges,
+      });
+      setResults(hits);
+      setResultsNumber(hitsNumber);
+    } catch (error_) {
+      setError('Під час пошуку сталася помилка. Будь ласка, спробуйте ще.');
+      console.error(error_);
+      ActiveBugsnag.notify(error_ as NotifiableError);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { searchValue, results, resultsNumber, loading, error, handleSearch };
+}
+
+export default useSearch;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,6 +7,13 @@
   box-sizing: border-box;
 }
 
+input[type='search']::-webkit-search-decoration,
+input[type='search']::-webkit-search-cancel-button,
+input[type='search']::-webkit-search-results-button,
+input[type='search']::-webkit-search-results-decoration {
+  -webkit-appearance: none;
+}
+
 /* Theme to start with */
 :root {
   --side-gap: 16px;


### PR DESCRIPTION
- make an input the only source of truth
- use URL query only as an initial value for a search, and then update it when calling for a search after the delay
- implement a debounced delay natively
- change input's type to search 
- move search handling to hook to be potentially refactored to be using library or library-like fetching (or at least its structure, caching, etc.)
- add results caption to have explicit loading state
- add search value explicitly to the results caption for a specific query
- fix appearance of results' second column when having a long URL (example query - їх;є)