### PR TITLE
Potential fix for code scanning alert no. 8: Clear-text logging of sensitive information

### DIFF
--- a/src/dockerize-typesense/get-typesense-admin-key.ts
+++ b/src/dockerize-typesense/get-typesense-admin-key.ts
@@ -8,7 +8,7 @@ export default async function getTypesenseAdminKey(
   apiKey: string,
   isBootstrap: boolean,
 ) {
-  console.log('getTypesenseAdminKey', apiKey, isBootstrap);
+  console.log('getTypesenseAdminKey called', { isBootstrap });
   if (!isBootstrap && process.env.TYPESENSE_ADMIN_KEY) {
     console.log('Typesense admin key already exists.');
     return process.env.TYPESENSE_ADMIN_KEY;


### PR DESCRIPTION
Potential fix for [https://github.com/undead404/koreni/security/code-scanning/8](https://github.com/undead404/koreni/security/code-scanning/8)

In general, the fix is to avoid logging sensitive values like API keys. If some logging is needed for debugging or traceability, log only non-sensitive context (e.g., that the function was called, or whether bootstrapping mode is active), and ensure that secret values are omitted or redacted.

For this specific function in `src/dockerize-typesense/get-typesense-admin-key.ts`, the best fix that preserves behavior is to remove `apiKey` from the log on line 11 and keep only non-sensitive information. We can still log that `getTypesenseAdminKey` was called and whether it is a bootstrap run using `isBootstrap`, which does not appear to be sensitive. No new imports or helper methods are required; a simple change to the existing `console.log` line is sufficient. The rest of the function (HTTP request, schema parsing, writing environment values, and success message) remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
