### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: CI/CD Pipeline
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/undead404/koreni/security/code-scanning/1](https://github.com/undead404/koreni/security/code-scanning/1)

To fix this, explicitly declare minimal `GITHUB_TOKEN` permissions in the workflow. The safest general pattern is to add a `permissions` block at the workflow root (top level, alongside `name` and `on`) that sets `contents: read`, which is sufficient for `actions/checkout` and does not grant write access. Jobs that only read the repo and talk to external services (using `secrets`/`vars`) will continue to work unchanged.

The single best way here without changing functionality is:

- Edit `.github/workflows/main.yml`.
- Insert a top‑level `permissions:` block right after the `name: CI/CD Pipeline` line and before the `on:` block:
  ```yaml
  name: CI/CD Pipeline
  permissions:
    contents: read
  on:
    ...
  ```
- This applies `contents: read` to all jobs (including `lint`, `test`, `populate-typesense`, `build`, and the elided `build-api` and `deploy`) unless any job later defines its own `permissions` block. None of the visible steps need write permissions, so behavior remains unchanged except that `GITHUB_TOKEN` can no longer mutate repository contents.

No new methods, imports, or additional configuration files are required; this is a pure YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
