### PR TITLE
fix: align Typesense bootstrap schema

### DIFF
--- a/src/dockerize-typesense/config.test.ts
+++ b/src/dockerize-typesense/config.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { IndexationTable } from '@/shared/schemas/indexation-table.js';
+
+import convertRow from '../populate-typesense/convert-row.js';
+import determineRowYear from '../populate-typesense/determine-row-year.js';
+
+import {
+  PL_COLLECTION_CONFIGURATION,
+  RU_COLLECTION_CONFIGURATION,
+  UK_COLLECTION_CONFIGURATION,
+} from './config';
+
+vi.mock('../populate-typesense/determine-row-year.js', () => ({
+  default: vi.fn(),
+}));
+
+describe('typesense collection configuration', () => {
+  const table: IndexationTable = {
+    archiveItems: ['Test archive item'],
+    authorEmail: 'john@example.com',
+    authorName: 'John Doe',
+    date: new Date('2023-01-01'),
+    id: 'test-table-123',
+    location: [50.4501, 30.5234],
+    size: 100,
+    sources: ['https://example.com/source'],
+    tableFilePath: 'data/test-table.csv',
+    tableLocale: 'uk',
+    title: 'Test Table',
+    yearsRange: [1900],
+  };
+
+  const row = {
+    Age: 25,
+    Name: ' Ivan ',
+    Notes: '  Some notes  ',
+  };
+
+  it.each([
+    ['Polish', PL_COLLECTION_CONFIGURATION],
+    ['Russian', RU_COLLECTION_CONFIGURATION],
+    ['Ukrainian', UK_COLLECTION_CONFIGURATION],
+  ] as const)(
+    'keeps the %s collection compatible with imported row documents',
+    (_label, configuration) => {
+      vi.mocked(determineRowYear).mockReturnValue(1905);
+
+      const document = convertRow(row, 0, table, table.location);
+      const schemaFieldNames = configuration.fields.map((field) => field.name);
+      const importedFieldNames = Object.keys(document).filter(
+        (fieldName) => fieldName !== 'id',
+      );
+
+      expect(schemaFieldNames).toEqual(
+        expect.arrayContaining(importedFieldNames),
+      );
+    },
+  );
+});

--- a/src/dockerize-typesense/config.ts
+++ b/src/dockerize-typesense/config.ts
@@ -8,15 +8,11 @@ export const PL_COLLECTION_CONFIGURATION = {
   name: 'unstructured_pl',
   enable_nested_fields: true,
   fields: [
-    {
-      dynamic: true,
-      locale: 'pl',
-      name: 'data',
-      optional: false,
-      type: 'object',
-    },
+    { locale: 'pl', name: 'values', optional: false, type: 'string[]' },
+    { name: 'raw', optional: false, type: 'object' },
     { name: 'location', type: 'geopoint' },
     { facet: true, name: 'tableId', type: 'string' },
+    { name: 'title', type: 'string' },
     { facet: true, name: 'year', type: 'int32' },
   ],
 };
@@ -25,15 +21,11 @@ export const RU_COLLECTION_CONFIGURATION = {
   name: 'unstructured_ru',
   enable_nested_fields: true,
   fields: [
-    {
-      dynamic: true,
-      locale: 'ru',
-      name: 'data',
-      optional: false,
-      type: 'object',
-    },
+    { locale: 'ru', name: 'values', optional: false, type: 'string[]' },
+    { name: 'raw', optional: false, type: 'object' },
     { name: 'location', type: 'geopoint' },
     { facet: true, name: 'tableId', type: 'string' },
+    { name: 'title', type: 'string' },
     { facet: true, name: 'year', type: 'int32' },
   ],
 };
@@ -42,15 +34,11 @@ export const UK_COLLECTION_CONFIGURATION = {
   name: 'unstructured_uk',
   enable_nested_fields: true,
   fields: [
-    {
-      dynamic: true,
-      locale: 'uk',
-      name: 'data',
-      optional: false,
-      type: 'object',
-    },
+    { locale: 'uk', name: 'values', optional: false, type: 'string[]' },
+    { name: 'raw', optional: false, type: 'object' },
     { name: 'location', type: 'geopoint' },
     { facet: true, name: 'tableId', type: 'string' },
+    { name: 'title', type: 'string' },
     { facet: true, name: 'year', type: 'int32' },
   ],
 };


### PR DESCRIPTION
This updates the bootstrap Typesense collection schema to match the current document shape produced by the importer and used by search.

Without this change, a fresh local setup can create collections with the old `data` schema, while the current pipeline indexes `values` and `raw`, which causes `yarn typesense:populate` to fail from scratch.

Also adds a small contract test to ensure the schema stays compatible with documents produced by `convertRow(...)`.

The bug appears to have been introduced in 3c2e981e, which switched the importer/search pipeline to `values` / `raw` but did not update the bootstrap Typesense collection schema.