### PR TITLE
fix: prevent token dropping in Typesense multi-word search

### DIFF
--- a/src/app/services/search.test.ts
+++ b/src/app/services/search.test.ts
@@ -79,6 +79,7 @@ describe('search', () => {
         union: true,
       },
       {
+        drop_tokens_threshold: 0,
         num_typos: 2,
         page: 1,
         per_page: 24,

--- a/src/app/services/search.ts
+++ b/src/app/services/search.ts
@@ -47,6 +47,7 @@ export default async function search({
   ];
 
   const commonParameters: Partial<MultiSearchRequestSchema> = {
+    drop_tokens_threshold: 0,
     page,
     per_page: perPage,
     query_by: 'values',


### PR DESCRIPTION
Ця зміна виправляє поведінку пошуку за кількома словами.

Раніше пошук міг "загубити" одне зі слів у запиті й показати результати, які насправді не містять усі слова. Наприклад, запит "Микола Ковбас" виводив 7 результатів, з них 4 "точних" містили лише слово "Микола", а слово "Ковбас" взагалі ні (навіть враховуючи `num_typos`). Це ставалось через поведінку параметра `drop_tokens_threshold` (https://typesense.org/docs/28.0/api/search.html#typo-tolerance-parameters), який не передавався, і отримував дефолтне значення 1, тобто дозволяв дропати слова з запиту допоки не буде хоча б 1 результат. Слова по-дефолту дропаються справа наліво (параметр  `drop_tokens_mode`).

Тепер пошук не відкидає слова із запиту, тому пошук буде більш логічним. 